### PR TITLE
Delete .gitattributes.txt

### DIFF
--- a/.gitattributes.txt
+++ b/.gitattributes.txt
@@ -1,2 +1,0 @@
-*.sql linguist-detectable=true
-*.sql linguist-language=sql


### PR DESCRIPTION
Learned that I can't force language to display as SQL. Don't need .gitattributes anymore.